### PR TITLE
Update CI workflows to use main branch

### DIFF
--- a/.github/workflows/pr_workflow.yml
+++ b/.github/workflows/pr_workflow.yml
@@ -1,12 +1,12 @@
-name: Pull Request & Master CI
+name: Pull Request & Main CI
 
 on:
   pull_request:
     branches:
-      - 'master'
+      - 'main'
   push:
     branches:
-      - 'master'
+      - 'main'
 
 jobs:
   test:


### PR DESCRIPTION
## Context
Master-slave is an oppressive metaphor and we can use better branch names easily.

Before this PR, I've updated the git repo
```
git branch -m master main
git push -u origin main
git push origin --delete master
```
Updated github settings:
```
Settings->branchs->
Default branch = main
Branch protection rules = main
```

## Code
- Update `master` branch references to `main`

