### PR TITLE
Improve BuildConfiguration class

### DIFF
--- a/app/src/main/java/br/com/recipebook/CustomApplication.kt
+++ b/app/src/main/java/br/com/recipebook/CustomApplication.kt
@@ -18,6 +18,18 @@ class CustomApplication : Application() {
 
     override fun onCreate() {
         super.onCreate()
+
+        // Crash report must be the first thing to initialize!
+        if (!BuildConfig.DEBUG) {
+            SentryAndroid.init(this)
+        }
+
+        initDI()
+
+        Fresco.initialize(this) // FIXME create abstraction layer and do a lazy init
+    }
+
+    private fun initDI() {
         // start Koin!
         startKoin {
             // declare used Android context
@@ -25,7 +37,7 @@ class CustomApplication : Application() {
             // declare modules
             modules(
                 buildModule +
-                coreAndroidModule +
+                        coreAndroidModule +
                         navigationModule +
                         recipeCollectionModules +
                         recipeDetailModules +
@@ -33,11 +45,6 @@ class CustomApplication : Application() {
                         settingsThemeModules +
                         amplitudeAnalyticsModule
             )
-        }
-        Fresco.initialize(this)
-
-        if (!BuildConfig.DEBUG) {
-            SentryAndroid.init(this)
         }
     }
 }

--- a/app/src/main/java/br/com/recipebook/di/buildModule.kt
+++ b/app/src/main/java/br/com/recipebook/di/buildModule.kt
@@ -9,7 +9,8 @@ val buildModule = module {
             appInfo = AppInfo(
                 name = BuildConfig.APPLICATION_ID,
                 version = BuildConfig.VERSION_NAME,
-                variant = BuildConfig.BUILD_TYPE
+                variant = BuildConfig.BUILD_TYPE,
+                buildVariant = if (BuildConfig.DEBUG) BuildVariant.DEBUG else BuildVariant.RELEASE
             ),
             apiKeys = ApiKeys(
                 sentryKey = BuildConfig.SENTRY_DSN,

--- a/infrastructure/analytics-amplitude/src/main/java/br/com/recipebook/analytics/amplitude/AmplitudeAnalytics.kt
+++ b/infrastructure/analytics-amplitude/src/main/java/br/com/recipebook/analytics/amplitude/AmplitudeAnalytics.kt
@@ -6,6 +6,7 @@ import br.com.recipebook.analytics.Analytics
 import br.com.recipebook.analytics.Event
 import br.com.recipebook.analytics.events.LibraryInitializationEvent
 import br.com.recipebook.di.BuildConfiguration
+import br.com.recipebook.di.BuildVariant
 import com.amplitude.api.Amplitude
 import org.json.JSONObject
 import kotlin.system.measureTimeMillis
@@ -29,9 +30,11 @@ class AmplitudeAnalytics(
                 .enableCoppaControl() // Turning off sensitive data tracking
         }
 
-        if (BuildConfig.DEBUG) {    // TODO inject
-            Amplitude.getInstance().setLogLevel(Log.VERBOSE)
+        val logLevel = when (buildConfiguration.appInfo.buildVariant) {
+            BuildVariant.DEBUG -> Log.VERBOSE
+            BuildVariant.RELEASE -> Log.INFO
         }
+        Amplitude.getInstance().setLogLevel(logLevel)
 
         isInitialized = true
         sendEvent(

--- a/infrastructure/configuration/src/main/java/br/com/recipebook/di/BuildConfiguration.kt
+++ b/infrastructure/configuration/src/main/java/br/com/recipebook/di/BuildConfiguration.kt
@@ -8,10 +8,16 @@ data class BuildConfiguration(
 data class AppInfo(
     val name: String,
     val version: String,
-    val variant: String
+    val variant: String,
+    val buildVariant: BuildVariant
 )
 
 data class ApiKeys(
     val sentryKey: String,
     val amplitudeKey: String
 )
+
+enum class BuildVariant {
+    RELEASE,
+    DEBUG
+}


### PR DESCRIPTION
## Context
We should not use the generated `BuildConfig` class directly because each modules has its own file, and that could lead to an unexpected value.

## Code
- Include the `BuildVariant` attribute into `BuildConfiguration` class
- Move Sentry init to the first line being executed. I'm not using `BuildConfiguration` class here because `Koin` is not initialized yet

