### PR TITLE
Swap LiveData to StateFlow

### DIFF
--- a/.github/workflows/release_workflow.yml
+++ b/.github/workflows/release_workflow.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test:
-    name: Run Unit Tests
+    name: Release - Run Unit Tests
     runs-on: ubuntu-18.04
 
     steps:

--- a/.github/workflows/release_workflow.yml
+++ b/.github/workflows/release_workflow.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     branches:
-      - 'release*'
+      - 'release'
 
 jobs:
   test:

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     dependencies {
         // classpath EnvironmentConfig.gradleTools
         // classpath EnvironmentConfig.gradlePlugin
-        classpath 'com.android.tools.build:gradle:4.0.0'
+        classpath 'com.android.tools.build:gradle:4.0.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.72"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/features/recipe-collection/src/main/java/br/com/recipebook/recipecollection/RecipeCollectionActivity.kt
+++ b/features/recipe-collection/src/main/java/br/com/recipebook/recipecollection/RecipeCollectionActivity.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.observe
 import br.com.recipebook.coreandroid.image.ImageResolver
 import br.com.recipebook.designsystem.ListMarginItemDecoration
 import br.com.recipebook.navigation.MainNavigator
@@ -15,6 +14,7 @@ import br.com.recipebook.recipecollection.presentation.RecipeCollectionActionFro
 import br.com.recipebook.recipecollection.presentation.RecipeCollectionActionToView
 import br.com.recipebook.recipecollection.presentation.RecipeCollectionViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.consumeEach
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import org.koin.android.ext.android.inject
@@ -84,13 +84,15 @@ class RecipeCollectionActivity : AppCompatActivity() {
     }
 
     private fun observeActionCommand() {
-        viewModel.actionToView.observe(this) {
-            when (it) {
-                is RecipeCollectionActionToView.OpenRecipeDetail -> {
-                    mainNavigator.navigate(
-                        this,
-                        RecipeDetailIntent(recipeId = it.recipeId, title = it.title)
-                    )
+        lifecycleScope.launch {
+            viewModel.actionToView.consumeEach {
+                when (it) {
+                    is RecipeCollectionActionToView.OpenRecipeDetail -> {
+                        mainNavigator.navigate(
+                            this@RecipeCollectionActivity,
+                            RecipeDetailIntent(recipeId = it.recipeId, title = it.title)
+                        )
+                    }
                 }
             }
         }

--- a/features/recipe-collection/src/main/java/br/com/recipebook/recipecollection/presentation/RecipeCollectionViewModel.kt
+++ b/features/recipe-collection/src/main/java/br/com/recipebook/recipecollection/presentation/RecipeCollectionViewModel.kt
@@ -9,8 +9,10 @@ import br.com.recipebook.recipecollection.view.RecipeItem
 import br.com.recipebook.utilityandroid.presentation.BaseViewModel
 import br.com.recipebook.utilitykotlin.CommonError
 import br.com.recipebook.utilitykotlin.ResultWrapper
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
 
+@ExperimentalCoroutinesApi
 class RecipeCollectionViewModel(
     override val viewState: RecipeCollectionViewState,
     private val getRecipeCollection: GetRecipeCollectionUseCase,

--- a/features/recipe-collection/src/main/java/br/com/recipebook/recipecollection/presentation/RecipeCollectionViewModel.kt
+++ b/features/recipe-collection/src/main/java/br/com/recipebook/recipecollection/presentation/RecipeCollectionViewModel.kt
@@ -70,9 +70,14 @@ class RecipeCollectionViewModel(
         viewState.recipes.value = emptyList()
     }
 
-    private fun openRecipeDetail(recipeId: String, title: String?) {
-        _actionToView.value = RecipeCollectionActionToView.OpenRecipeDetail(
-            recipeId = recipeId, title = title
+    private fun openRecipeDetail(
+        recipeId: String,
+        title: String?
+    ) = viewModelScope.launch {
+        actionToView.send(
+            RecipeCollectionActionToView.OpenRecipeDetail(
+                recipeId = recipeId, title = title
+            )
         )
     }
 

--- a/features/recipe-collection/src/main/java/br/com/recipebook/recipecollection/presentation/RecipeCollectionViewState.kt
+++ b/features/recipe-collection/src/main/java/br/com/recipebook/recipecollection/presentation/RecipeCollectionViewState.kt
@@ -1,10 +1,12 @@
 package br.com.recipebook.recipecollection.presentation
 
-import androidx.lifecycle.MutableLiveData
 import br.com.recipebook.recipecollection.view.RecipeItem
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
 
+@ExperimentalCoroutinesApi
 class RecipeCollectionViewState {
-    val recipes = MutableLiveData<List<RecipeItem>>()
-    val isLoading = MutableLiveData<Boolean>()
-    val hasError = MutableLiveData<Boolean>()
+    val recipes = MutableStateFlow<List<RecipeItem>>(emptyList())
+    val isLoading = MutableStateFlow(false)
+    val hasError = MutableStateFlow(false)
 }

--- a/features/recipe-detail/src/main/java/br/com/recipebook/recipedetail/presentation/RecipeDetailViewModel.kt
+++ b/features/recipe-detail/src/main/java/br/com/recipebook/recipedetail/presentation/RecipeDetailViewModel.kt
@@ -12,8 +12,10 @@ import br.com.recipebook.recipedetail.presentation.model.RecipeDetailItem
 import br.com.recipebook.recipedetail.view.RecipeDetailSafeArgs
 import br.com.recipebook.utilityandroid.presentation.BaseViewModel
 import br.com.recipebook.utilitykotlin.CommonError
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
 
+@ExperimentalCoroutinesApi
 class RecipeDetailViewModel(
     private val safeArgs: RecipeDetailSafeArgs,
     override val viewState: RecipeDetailViewState,

--- a/features/recipe-detail/src/main/java/br/com/recipebook/recipedetail/presentation/RecipeDetailViewState.kt
+++ b/features/recipe-detail/src/main/java/br/com/recipebook/recipedetail/presentation/RecipeDetailViewState.kt
@@ -1,14 +1,16 @@
 package br.com.recipebook.recipedetail.presentation
 
-import androidx.lifecycle.MutableLiveData
 import br.com.recipebook.recipedetail.presentation.model.RecipeDetailItem
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
 
+@ExperimentalCoroutinesApi
 class RecipeDetailViewState {
-    val isLoading = MutableLiveData<Boolean>()
+    val isLoading = MutableStateFlow(true)
 
-    val hasError = MutableLiveData<Boolean>()
+    val hasError = MutableStateFlow(false)
 
-    val recipeImage = MutableLiveData<String>()
-    val title = MutableLiveData<String>()
-    val listItems = MutableLiveData<List<RecipeDetailItem>>()
+    val recipeImage = MutableStateFlow<String?>(null)
+    val title = MutableStateFlow<String?>(null)
+    val listItems = MutableStateFlow<List<RecipeDetailItem>>(emptyList())
 }

--- a/features/recipe-detail/src/main/java/br/com/recipebook/recipedetail/view/RecipeDetailNavigator.kt
+++ b/features/recipe-detail/src/main/java/br/com/recipebook/recipedetail/view/RecipeDetailNavigator.kt
@@ -4,7 +4,9 @@ import android.content.Context
 import br.com.recipebook.navigation.Navigator
 import br.com.recipebook.navigation.intent.NavIntent
 import br.com.recipebook.navigation.intent.RecipeDetailIntent
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 
+@ExperimentalCoroutinesApi
 class RecipeDetailNavigator : Navigator {
     override var intentList = listOf(RecipeDetailIntent::class.java)
 

--- a/features/settings-theme/src/main/java/br/com/recipebook/settings/theme/presentation/SettingsThemeViewModel.kt
+++ b/features/settings-theme/src/main/java/br/com/recipebook/settings/theme/presentation/SettingsThemeViewModel.kt
@@ -8,8 +8,10 @@ import br.com.recipebook.settings.theme.domain.usecase.GetUserThemePreferenceUse
 import br.com.recipebook.settings.theme.domain.usecase.SetUserThemePreferenceUseCase
 import br.com.recipebook.utilityandroid.presentation.BaseViewModel
 import br.com.recipebook.utilitykotlin.CommonError
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
 
+@ExperimentalCoroutinesApi
 class SettingsThemeViewModel(
     override val viewState: SettingsThemeViewState,
     private val getUserThemePreference: GetUserThemePreferenceUseCase,

--- a/features/settings-theme/src/main/java/br/com/recipebook/settings/theme/presentation/SettingsThemeViewState.kt
+++ b/features/settings-theme/src/main/java/br/com/recipebook/settings/theme/presentation/SettingsThemeViewState.kt
@@ -1,13 +1,15 @@
 package br.com.recipebook.settings.theme.presentation
 
-import androidx.lifecycle.MutableLiveData
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
 
+@ExperimentalCoroutinesApi
 class SettingsThemeViewState {
-    val isLoading = MutableLiveData<Boolean>()
+    val isLoading = MutableStateFlow(true)
 
-    val hasError = MutableLiveData<Boolean>()
+    val hasError = MutableStateFlow(false)
 
-    val isSystemThemeSelected = MutableLiveData<Boolean>()
-    val isLightThemeSelected = MutableLiveData<Boolean>()
-    val isDarkThemeSelected = MutableLiveData<Boolean>()
+    val isSystemThemeSelected = MutableStateFlow(false)
+    val isLightThemeSelected = MutableStateFlow(false)
+    val isDarkThemeSelected = MutableStateFlow(false)
 }

--- a/features/settings-theme/src/main/java/br/com/recipebook/settings/theme/view/SettingsThemeActivity.kt
+++ b/features/settings-theme/src/main/java/br/com/recipebook/settings/theme/view/SettingsThemeActivity.kt
@@ -6,7 +6,6 @@ import android.os.Bundle
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.observe
 import br.com.recipebook.settings.theme.R
 import br.com.recipebook.settings.theme.databinding.SettingsThemeActivityBinding
 import br.com.recipebook.settings.theme.presentation.SettingsThemeActionFromView
@@ -26,7 +25,6 @@ class SettingsThemeActivity : AppCompatActivity() {
             initComponents(this)
             setContentView(root)
             observeState(this)
-            observeActionCommand()
         }
     }
 
@@ -79,11 +77,6 @@ class SettingsThemeActivity : AppCompatActivity() {
             viewModel.viewState.isDarkThemeSelected.collect {
                 binding.settingsThemeDark.isChecked = it
             }
-        }
-    }
-
-    private fun observeActionCommand() {
-        viewModel.actionToView.observe(this) {
         }
     }
 

--- a/features/settings-theme/src/main/java/br/com/recipebook/settings/theme/view/SettingsThemeActivity.kt
+++ b/features/settings-theme/src/main/java/br/com/recipebook/settings/theme/view/SettingsThemeActivity.kt
@@ -5,13 +5,18 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.observe
 import br.com.recipebook.settings.theme.R
 import br.com.recipebook.settings.theme.databinding.SettingsThemeActivityBinding
 import br.com.recipebook.settings.theme.presentation.SettingsThemeActionFromView
 import br.com.recipebook.settings.theme.presentation.SettingsThemeViewModel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
+@ExperimentalCoroutinesApi
 class SettingsThemeActivity : AppCompatActivity() {
     private val viewModel: SettingsThemeViewModel by viewModel()
 
@@ -50,20 +55,30 @@ class SettingsThemeActivity : AppCompatActivity() {
     }
 
     private fun observeState(binding: SettingsThemeActivityBinding) {
-        viewModel.viewState.isLoading.observe(this) {
-            binding.settingsLoading.visibility = if (it) View.VISIBLE else View.GONE
+        lifecycleScope.launch {
+            viewModel.viewState.isLoading.collect {
+                binding.settingsLoading.visibility = if (it) View.VISIBLE else View.GONE
+            }
         }
-        viewModel.viewState.hasError.observe(this) {
-            binding.settingsErrorState.root.visibility = if (it) View.VISIBLE else View.GONE
+        lifecycleScope.launch {
+            viewModel.viewState.hasError.collect {
+                binding.settingsErrorState.root.visibility = if (it) View.VISIBLE else View.GONE
+            }
         }
-        viewModel.viewState.isSystemThemeSelected.observe(this) {
-            binding.settingsThemeSystemDefault.isChecked = it
+        lifecycleScope.launch {
+            viewModel.viewState.isSystemThemeSelected.collect {
+                binding.settingsThemeSystemDefault.isChecked = it
+            }
         }
-        viewModel.viewState.isLightThemeSelected.observe(this) {
-            binding.settingsThemeLight.isChecked = it
+        lifecycleScope.launch {
+            viewModel.viewState.isLightThemeSelected.collect {
+                binding.settingsThemeLight.isChecked = it
+            }
         }
-        viewModel.viewState.isDarkThemeSelected.observe(this) {
-            binding.settingsThemeDark.isChecked = it
+        lifecycleScope.launch {
+            viewModel.viewState.isDarkThemeSelected.collect {
+                binding.settingsThemeDark.isChecked = it
+            }
         }
     }
 

--- a/features/settings-theme/src/main/java/br/com/recipebook/settings/theme/view/SettingsThemeNavigator.kt
+++ b/features/settings-theme/src/main/java/br/com/recipebook/settings/theme/view/SettingsThemeNavigator.kt
@@ -4,7 +4,9 @@ import android.content.Context
 import br.com.recipebook.navigation.Navigator
 import br.com.recipebook.navigation.intent.NavIntent
 import br.com.recipebook.navigation.intent.SettingsThemeIntent
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 
+@ExperimentalCoroutinesApi
 class SettingsThemeNavigator : Navigator {
     override var intentList = listOf(SettingsThemeIntent::class.java)
 

--- a/features/settings/src/main/java/br/com/recipebook/settings/presentation/SettingsViewModel.kt
+++ b/features/settings/src/main/java/br/com/recipebook/settings/presentation/SettingsViewModel.kt
@@ -26,10 +26,11 @@ class SettingsViewModel(
     }
 
     override fun dispatchAction(action: SettingsActionFromView) {
-        when (action) {
-            is SettingsActionFromView.ItemClick ->
-                _actionToView.value =
-                    SettingsActionToView.OpenItem(action.settingsItem.navIntent)
+        viewModelScope.launch {
+            when (action) {
+                is SettingsActionFromView.ItemClick ->
+                    actionToView.send(SettingsActionToView.OpenItem(action.settingsItem.navIntent))
+            }
         }
     }
 

--- a/features/settings/src/main/java/br/com/recipebook/settings/presentation/SettingsViewModel.kt
+++ b/features/settings/src/main/java/br/com/recipebook/settings/presentation/SettingsViewModel.kt
@@ -8,8 +8,10 @@ import br.com.recipebook.settings.domain.usecase.GetSettingsUseCase
 import br.com.recipebook.settings.presentation.model.SettingsItem
 import br.com.recipebook.utilityandroid.presentation.BaseViewModel
 import br.com.recipebook.utilitykotlin.CommonError
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
 
+@ExperimentalCoroutinesApi
 class SettingsViewModel(
     override val viewState: SettingsViewState,
     private val getSettingsList: GetSettingsUseCase,

--- a/features/settings/src/main/java/br/com/recipebook/settings/presentation/SettingsViewState.kt
+++ b/features/settings/src/main/java/br/com/recipebook/settings/presentation/SettingsViewState.kt
@@ -1,12 +1,14 @@
 package br.com.recipebook.settings.presentation
 
-import androidx.lifecycle.MutableLiveData
 import br.com.recipebook.settings.presentation.model.SettingsItem
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
 
+@ExperimentalCoroutinesApi
 class SettingsViewState {
-    val isLoading = MutableLiveData<Boolean>()
+    val isLoading = MutableStateFlow(true)
 
-    val hasError = MutableLiveData<Boolean>()
+    val hasError = MutableStateFlow(false)
 
-    val listItems = MutableLiveData<List<SettingsItem>>()
+    val listItems = MutableStateFlow<List<SettingsItem>>(emptyList())
 }

--- a/features/settings/src/main/java/br/com/recipebook/settings/view/SettingsActivity.kt
+++ b/features/settings/src/main/java/br/com/recipebook/settings/view/SettingsActivity.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.observe
 import androidx.recyclerview.widget.LinearLayoutManager
 import br.com.recipebook.designsystem.ListMarginItemDecoration
@@ -15,9 +16,13 @@ import br.com.recipebook.settings.presentation.SettingsActionFromView
 import br.com.recipebook.settings.presentation.SettingsActionToView
 import br.com.recipebook.settings.presentation.SettingsViewModel
 import br.com.recipebook.settings.presentation.model.SettingsItem
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
 import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
+@ExperimentalCoroutinesApi
 class SettingsActivity : AppCompatActivity() {
     private val viewModel: SettingsViewModel by viewModel()
     private val adapter by lazy { SettingsListAdapter(onItemClick = ::onItemClick) }
@@ -54,14 +59,20 @@ class SettingsActivity : AppCompatActivity() {
     }
 
     private fun observeState(binding: SettingsActivityBinding) {
-        viewModel.viewState.isLoading.observe(this) {
-            binding.settingsLoading.visibility = if (it) View.VISIBLE else View.GONE
+        lifecycleScope.launch {
+            viewModel.viewState.isLoading.collect {
+                binding.settingsLoading.visibility = if (it) View.VISIBLE else View.GONE
+            }
         }
-        viewModel.viewState.hasError.observe(this) {
-            binding.settingsErrorState.root.visibility = if (it) View.VISIBLE else View.GONE
+        lifecycleScope.launch {
+            viewModel.viewState.hasError.collect {
+                binding.settingsErrorState.root.visibility = if (it) View.VISIBLE else View.GONE
+            }
         }
-        viewModel.viewState.listItems.observe(this) {
-            adapter.setData(it)
+        lifecycleScope.launch {
+            viewModel.viewState.listItems.collect {
+                adapter.setData(it)
+            }
         }
     }
 

--- a/features/settings/src/main/java/br/com/recipebook/settings/view/SettingsActivity.kt
+++ b/features/settings/src/main/java/br/com/recipebook/settings/view/SettingsActivity.kt
@@ -6,7 +6,6 @@ import android.os.Bundle
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.observe
 import androidx.recyclerview.widget.LinearLayoutManager
 import br.com.recipebook.designsystem.ListMarginItemDecoration
 import br.com.recipebook.navigation.MainNavigator
@@ -17,6 +16,7 @@ import br.com.recipebook.settings.presentation.SettingsActionToView
 import br.com.recipebook.settings.presentation.SettingsViewModel
 import br.com.recipebook.settings.presentation.model.SettingsItem
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.consumeEach
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import org.koin.android.ext.android.inject
@@ -77,13 +77,15 @@ class SettingsActivity : AppCompatActivity() {
     }
 
     private fun observeActionCommand() {
-        viewModel.actionToView.observe(this) {
-            when (it) {
-                is SettingsActionToView.OpenItem -> {
-                    mainNavigator.navigate(
-                        this,
-                        it.navIntent
-                    )
+        lifecycleScope.launch {
+            viewModel.actionToView.consumeEach {
+                when (it) {
+                    is SettingsActionToView.OpenItem -> {
+                        mainNavigator.navigate(
+                            this@SettingsActivity,
+                            it.navIntent
+                        )
+                    }
                 }
             }
         }

--- a/features/settings/src/main/java/br/com/recipebook/settings/view/SettingsNavigator.kt
+++ b/features/settings/src/main/java/br/com/recipebook/settings/view/SettingsNavigator.kt
@@ -4,7 +4,9 @@ import android.content.Context
 import br.com.recipebook.navigation.Navigator
 import br.com.recipebook.navigation.intent.NavIntent
 import br.com.recipebook.navigation.intent.SettingsIntent
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 
+@ExperimentalCoroutinesApi
 class SettingsNavigator : Navigator {
     override var intentList = listOf(SettingsIntent::class.java)
 

--- a/project-config/dependencies.gradle
+++ b/project-config/dependencies.gradle
@@ -1,6 +1,6 @@
 ext {
     kotlinVersion = "1.3.72"
-    gradleVersion = "4.0.0"
+    gradleVersion = "4.0.1"
     jvmTargetVersion = "1.8"
     
     EnvironmentConfig = [
@@ -24,7 +24,7 @@ ext {
     
     AndroidLibConfig = [
         coreKtx: "androidx.core:core-ktx:1.2.0",
-        coroutinesCore: "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.1.1",
+        coroutinesCore: "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.7",
 
         // Network related libraries
         retrofit: "com.squareup.retrofit2:retrofit:2.8.1",

--- a/project-config/dependencies.gradle
+++ b/project-config/dependencies.gradle
@@ -38,7 +38,6 @@ ext {
         recyclerView: "androidx.recyclerview:recyclerview:1.1.0",
         cardView: "androidx.cardview:cardview:1.0.0",
         viewmodel: "androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0",
-        livedata: "androidx.lifecycle:lifecycle-livedata-ktx:2.2.0",
         fragment: "androidx.fragment:fragment-ktx:1.2.2",
         swipeRefresh: "androidx.swiperefreshlayout:swiperefreshlayout:1.0.0",
         coordinatorLayout: "androidx.coordinatorlayout:coordinatorlayout:1.1.0",

--- a/project-config/feature-complete-build.gradle
+++ b/project-config/feature-complete-build.gradle
@@ -55,7 +55,6 @@ dependencies {
     implementation AndroidLibConfig.recyclerView
     implementation AndroidLibConfig.cardView
     implementation AndroidLibConfig.viewmodel
-    implementation AndroidLibConfig.livedata
     implementation AndroidLibConfig.fragment
 
     implementation AndroidLibConfig.fresco

--- a/utility/utility-android/src/main/java/br/com/recipebook/utilityandroid/presentation/BaseViewModel.kt
+++ b/utility/utility-android/src/main/java/br/com/recipebook/utilityandroid/presentation/BaseViewModel.kt
@@ -1,14 +1,11 @@
 package br.com.recipebook.utilityandroid.presentation
 
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.channels.Channel
 
 abstract class BaseViewModel<ViewState, ActionFromView, ActionToView> : ViewModel() {
     abstract val viewState: ViewState
-
-    protected val _actionToView = MutableLiveData<ActionToView>()
-    val actionToView: LiveData<ActionToView> get() = _actionToView
+    val actionToView = Channel<ActionToView>()
 
     abstract fun dispatchAction(action: ActionFromView)
 }


### PR DESCRIPTION
## Context
With the rise in popularity of Coroutines and Flow, Kotlin released Stateflow API as part of v1.3.6.
StateFlow is like a way to use Kotlin Flow to manage and represent a state in an application, like LiveData but not attached to Android

## Code
- Almost just swapping LiveData to StateFlow
- StateFlow needs a initial state
- We need to annotate classes with @ExperimentalCoroutinesApi

