### PR TITLE
Removing icon and fixing AppBar bug

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CompilerConfiguration">
+    <bytecodeTargetLevel target="1.8" />
+  </component>
+</project>

--- a/build.gradle
+++ b/build.gradle
@@ -9,8 +9,8 @@ buildscript {
     dependencies {
         // classpath EnvironmentConfig.gradleTools
         // classpath EnvironmentConfig.gradlePlugin
-        classpath 'com.android.tools.build:gradle:4.0.1'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.0"
+        classpath 'com.android.tools.build:gradle:4.1.1'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.20"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/features/recipe-detail/src/main/java/br/com/recipebook/recipedetail/presentation/RecipeDetailViewState.kt
+++ b/features/recipe-detail/src/main/java/br/com/recipebook/recipedetail/presentation/RecipeDetailViewState.kt
@@ -10,7 +10,7 @@ class RecipeDetailViewState {
 
     val hasError = MutableStateFlow(false)
 
-    val recipeImage = MutableStateFlow<String?>(null)
+    val recipeImage = MutableStateFlow<String?>("")
     val title = MutableStateFlow<String?>(null)
     val listItems = MutableStateFlow<List<RecipeDetailItem>>(emptyList())
 }

--- a/features/recipe-detail/src/main/java/br/com/recipebook/recipedetail/view/RecipeDetailActivity.kt
+++ b/features/recipe-detail/src/main/java/br/com/recipebook/recipedetail/view/RecipeDetailActivity.kt
@@ -14,6 +14,7 @@ import br.com.recipebook.recipedetail.R
 import br.com.recipebook.recipedetail.databinding.RecipeDetailActivityBinding
 import br.com.recipebook.recipedetail.presentation.RecipeDetailViewModel
 import br.com.recipebook.utilityandroid.view.activitySafeArgs
+import br.com.recipebook.utilityandroid.view.appbarlayout.setCollapsedAndDisableScroll
 import br.com.recipebook.utilityandroid.view.putSafeArgs
 import com.google.android.material.appbar.AppBarLayout
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -28,7 +29,7 @@ class RecipeDetailActivity : AppCompatActivity() {
 
     private val viewModel: RecipeDetailViewModel by viewModel(parameters = { parametersOf(safeArgs) })
     private val imageResolver: ImageResolver by inject()
-    private val adapter by lazy { RecipeDetailListAdapter(imageResolver) }
+    private val adapter by lazy { RecipeDetailListAdapter() }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -91,7 +92,7 @@ class RecipeDetailActivity : AppCompatActivity() {
             viewModel.viewState.hasError.collect {
                 if (it) {
                     binding.recipeDetailErrorState.root.visibility = View.VISIBLE
-                    binding.appBarLayout.setExpanded(false)
+                    binding.appBarLayout.setCollapsedAndDisableScroll(binding.recipeDetailList)
                 } else {
                     binding.recipeDetailErrorState.root.visibility = View.GONE
                 }
@@ -106,7 +107,11 @@ class RecipeDetailActivity : AppCompatActivity() {
 
         lifecycleScope.launchWhenStarted {
             viewModel.viewState.recipeImage.collect {
-                binding.recipeImage.setImageURI(imageResolver.mountUrl(it, ImageSize.LARGE))
+                if (it != null) {
+                    binding.recipeImage.setImageURI(imageResolver.mountUrl(it, ImageSize.LARGE))
+                } else {
+                    binding.appBarLayout.setCollapsedAndDisableScroll(binding.recipeDetailList)
+                }
             }
         }
 

--- a/features/recipe-detail/src/main/java/br/com/recipebook/recipedetail/view/RecipeDetailListAdapter.kt
+++ b/features/recipe-detail/src/main/java/br/com/recipebook/recipedetail/view/RecipeDetailListAdapter.kt
@@ -4,8 +4,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
-import br.com.recipebook.coreandroid.image.ImageResolver
-import br.com.recipebook.coreandroid.image.ImageSize
 import br.com.recipebook.recipedetail.R
 import br.com.recipebook.recipedetail.databinding.RecipeDetailListItemBinding
 import br.com.recipebook.recipedetail.databinding.RecipeDetailListItemHeaderBinding
@@ -20,9 +18,7 @@ private enum class ViewType {
     HEADER_INSTRUCTIONS
 }
 
-class RecipeDetailListAdapter(
-    private val imageResolver: ImageResolver
-) : RecyclerView.Adapter<RecipeDetailListAdapter.ViewHolder>() {
+class RecipeDetailListAdapter : RecyclerView.Adapter<RecipeDetailListAdapter.ViewHolder>() {
 
     private var list = emptyList<RecipeDetailItem>()
 
@@ -48,7 +44,6 @@ class RecipeDetailListAdapter(
                         parent,
                         false
                     ),
-                    imageResolver = imageResolver
                 )
             else -> throw ClassNotFoundException()
         }
@@ -95,23 +90,10 @@ class RecipeDetailListAdapter(
 
         class DescriptionViewHolder(
             private val binding: RecipeDetailListItemBinding,
-            private val imageResolver: ImageResolver
         ) : ViewHolder(binding.root) {
 
             fun bind(item: DescriptionItem) {
                 with(binding) {
-
-                    if (!item.imgPath.isNullOrBlank()) {
-                        recipeDetailItemImage.setImageURI(
-                            imageResolver.mountUrl(
-                                item.imgPath,
-                                ImageSize.SMALL
-                            )
-                        )
-                        recipeDetailItemImage.visibility = View.VISIBLE
-                    } else {
-                        recipeDetailItemImage.visibility = View.INVISIBLE
-                    }
                     recipeDetailItemDescription.text = item.description
                 }
             }

--- a/features/recipe-detail/src/main/res/layout/recipe_detail_list_item.xml
+++ b/features/recipe-detail/src/main/res/layout/recipe_detail_list_item.xml
@@ -5,17 +5,11 @@
     android:layout_height="wrap_content"
     android:orientation="horizontal">
 
-    <com.facebook.drawee.view.SimpleDraweeView
-        android:id="@+id/recipe_detail_item_image"
-        android:layout_width="@dimen/icon_size"
-        android:layout_height="@dimen/icon_size"
-        android:scaleType="centerCrop"
-        tools:src="@tools:sample/backgrounds/scenic" />
-
     <TextView
         android:id="@+id/recipe_detail_item_description"
         style="@style/Style.DS.ListTextual.Item"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:paddingStart="@dimen/margin_large_100"
         tools:text="2 xícaras de trigo" />
 </LinearLayout>

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sun May 17 14:26:48 BRT 2020
+#Thu Dec 24 11:13:58 BRT 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip

--- a/project-config/dependencies.gradle
+++ b/project-config/dependencies.gradle
@@ -1,6 +1,6 @@
 ext {
-    kotlinVersion = "1.4.0"
-    gradleVersion = "4.0.1"
+    kotlinVersion = "1.4.20"
+    gradleVersion = "4.1.1"
     jvmTargetVersion = "1.8"
     
     EnvironmentConfig = [

--- a/utility/utility-android/build.gradle
+++ b/utility/utility-android/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     implementation AndroidLibConfig.constraintLayout
     implementation AndroidLibConfig.recyclerView
     implementation AndroidLibConfig.cardView
+    implementation AndroidLibConfig.material
 
     testImplementation TestConfig.jUnit
 

--- a/utility/utility-android/src/main/java/br/com/recipebook/utilityandroid/view/appbarlayout/AppBarLayoutExtensions.kt
+++ b/utility/utility-android/src/main/java/br/com/recipebook/utilityandroid/view/appbarlayout/AppBarLayoutExtensions.kt
@@ -1,0 +1,20 @@
+package br.com.recipebook.utilityandroid.view.appbarlayout
+
+import androidx.coordinatorlayout.widget.CoordinatorLayout
+import androidx.core.view.ViewCompat
+import androidx.recyclerview.widget.RecyclerView
+import com.google.android.material.appbar.AppBarLayout
+
+fun AppBarLayout.setCollapsedAndDisableScroll(recyclerView: RecyclerView) {
+    // Collapse AppBar
+    setExpanded(false)
+    // Disable AppBar scroll from the recycler view
+    ViewCompat.setNestedScrollingEnabled(recyclerView, false)
+    // Disable AppBar scroll from the AppBar
+    ((layoutParams as CoordinatorLayout.LayoutParams).behavior as AppBarLayout.Behavior)
+        .setDragCallback(object : AppBarLayout.Behavior.DragCallback() {
+            override fun canDrag(appBarLayout: AppBarLayout): Boolean {
+                return false
+            }
+        })
+}


### PR DESCRIPTION
## Context
- Removing icon from Recipe details and fixing AppBar "bug": lock expansion if no screen header image was loaded

## Code
- Removing `recipe_detail_item_image` view
- Create extension `AppBarLayout.setCollapsedAndDisableScroll`

## Additional notes
| Before | After |
| -- | -- |
|![image](https://user-images.githubusercontent.com/38049362/103151968-bdfff480-4761-11eb-9d75-b825893ff313.png) | ![image](https://user-images.githubusercontent.com/38049362/103151856-a70cd280-4760-11eb-9a5e-209b66c4f5d6.png) |
|![recipe-toolbar-bug](https://user-images.githubusercontent.com/38049362/103151988-f1db1a00-4761-11eb-982a-c02f75670cae.gif)|![recipe_toolbar_fix](https://user-images.githubusercontent.com/38049362/103151894-efc48b80-4760-11eb-9972-9a9bdcdf5f3e.gif)|
