### PR TITLE
Dependency version checker

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK" />
 </project>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -71,5 +71,5 @@ dependencies {
     implementation project(Features.settingsTheme)
 
     // debugImplementation because LeakCanary should only run in debug builds.
-    debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.4'
+    debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.5'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: "com.android.application"
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 
 apply from: "$rootDir/project-config/api-properties/api-properties.gradle"
 apply from: "$rootDir/quality/test-coverage.gradle"

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,10 @@
+// Dependency version definitions
 apply from: "project-config/dependencies.gradle"
+
+// Dependency version checker
+// Usage: ./gradlew dependencyUpdates -Drevision=release
+apply plugin: "com.github.ben-manes.versions"
+apply from: "project-config/dependencies-checker/dependencies-checker.gradle"
 
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
@@ -10,7 +16,8 @@ buildscript {
         // classpath EnvironmentConfig.gradleTools
         // classpath EnvironmentConfig.gradlePlugin
         classpath 'com.android.tools.build:gradle:4.1.1'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.20"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.21"
+        classpath "com.github.ben-manes:gradle-versions-plugin:0.36.0"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/build.gradle
+++ b/build.gradle
@@ -12,11 +12,14 @@ buildscript {
         google()
         jcenter()
     }
+    ext {
+        kotlinVersion = "1.4.21"
+        gradleVersion = "4.1.1"
+    }
+
     dependencies {
-        // classpath EnvironmentConfig.gradleTools
-        // classpath EnvironmentConfig.gradlePlugin
-        classpath 'com.android.tools.build:gradle:4.1.1'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.21"
+        classpath "com.android.tools.build:gradle:$gradleVersion"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         classpath "com.github.ben-manes:gradle-versions-plugin:0.36.0"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/core-android/build.gradle
+++ b/core-android/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: "com.android.library"
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 
 apply from: "$rootDir/quality/test-coverage.gradle"
 

--- a/features/recipe-detail/build.gradle
+++ b/features/recipe-detail/build.gradle
@@ -1,4 +1,5 @@
 apply from: "$rootDir/project-config/feature-complete-build.gradle"
+apply plugin: 'kotlin-parcelize'
 
 dependencies {
     implementation AndroidLibConfig.swipeRefresh

--- a/infrastructure/analytics-amplitude/build.gradle
+++ b/infrastructure/analytics-amplitude/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: "com.android.library"
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion AndroidConfig.compileSdk

--- a/infrastructure/design-system/build.gradle
+++ b/infrastructure/design-system/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: "com.android.library"
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion AndroidConfig.compileSdk

--- a/infrastructure/monitoring/build.gradle
+++ b/infrastructure/monitoring/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: "com.android.library"
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion AndroidConfig.compileSdk

--- a/infrastructure/monitoring/src/main/java/br/com/recipebook/monitoring/crashreport/Monitoring.kt
+++ b/infrastructure/monitoring/src/main/java/br/com/recipebook/monitoring/crashreport/Monitoring.kt
@@ -1,6 +1,6 @@
 package br.com.recipebook.monitoring.crashreport
 
-import io.sentry.core.Sentry
+import io.sentry.Sentry
 
 sealed class Breadcrumb(val value: String) {
     object StartupJobFinished : Breadcrumb("STARTUP_JOBS_FINISHED")

--- a/infrastructure/monitoring/src/main/java/br/com/recipebook/monitoring/crashreport/SentryTree.kt
+++ b/infrastructure/monitoring/src/main/java/br/com/recipebook/monitoring/crashreport/SentryTree.kt
@@ -1,8 +1,8 @@
 package br.com.recipebook.monitoring.crashreport
 
 import android.util.Log
-import io.sentry.core.Sentry
-import io.sentry.core.SentryLevel
+import io.sentry.Sentry
+import io.sentry.SentryLevel
 import timber.log.Timber
 
 class SentryTree : Timber.Tree() {

--- a/infrastructure/navigation/build.gradle
+++ b/infrastructure/navigation/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: "com.android.library"
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion AndroidConfig.compileSdk

--- a/project-config/dependencies-checker/dependencies-checker.gradle
+++ b/project-config/dependencies-checker/dependencies-checker.gradle
@@ -1,0 +1,12 @@
+def isNonStable = { String version ->
+  def stableKeyword = ['RELEASE', 'FINAL', 'GA'].any { it -> version.toUpperCase().contains(it) }
+  def regex = /^[0-9,.v-]+(-r)?$/
+  return !stableKeyword && !(version ==~ regex)
+}
+
+tasks.named("dependencyUpdates").configure {
+  // Reject all non stable versions
+  rejectVersionIf {
+    isNonStable(it.candidate.version)
+  }
+}

--- a/project-config/dependencies.gradle
+++ b/project-config/dependencies.gradle
@@ -83,7 +83,7 @@ ext {
 
     TestConfig = [
         jUnit: "junit:junit:4.13.1",
-        mockk: "io.mockk:mockk:1.10.3"
+        mockk: "io.mockk:mockk:1.10.2"
     ]
 
 }

--- a/project-config/dependencies.gradle
+++ b/project-config/dependencies.gradle
@@ -1,6 +1,4 @@
 ext {
-    kotlinVersion = "1.4.21"
-    gradleVersion = "4.1.1"
     jvmTargetVersion = "1.8"
     
     EnvironmentConfig = [

--- a/project-config/dependencies.gradle
+++ b/project-config/dependencies.gradle
@@ -21,40 +21,40 @@ ext {
     ]
     
     AndroidLibConfig = [
-        coreKtx: "androidx.core:core-ktx:1.3.1",
-        coroutinesCore: "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.9",
+        coreKtx: "androidx.core:core-ktx:1.3.2",
+        coroutinesCore: "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.2",
 
         // Network related libraries
         retrofit: "com.squareup.retrofit2:retrofit:2.9.0",
         moshiConverter: "com.squareup.retrofit2:converter-moshi:2.9.0",
-        moshiCodeGen: "com.squareup.moshi:moshi-kotlin-codegen:1.9.3",
-        moshi: "com.squareup.moshi:moshi:1.9.3",
+        moshiCodeGen: "com.squareup.moshi:moshi-kotlin-codegen:1.11.0",
+        moshi: "com.squareup.moshi:moshi:1.11.0",
 
         // Android components
         appCompat: "androidx.appcompat:appcompat:1.2.0",
-        constraintLayout: "androidx.constraintlayout:constraintlayout:1.1.3",
+        constraintLayout: "androidx.constraintlayout:constraintlayout:2.0.4",
         recyclerView: "androidx.recyclerview:recyclerview:1.1.0",
         cardView: "androidx.cardview:cardview:1.0.0",
         viewmodel: "androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0",
         fragment: "androidx.fragment:fragment-ktx:1.2.5",
-        swipeRefresh: "androidx.swiperefreshlayout:swiperefreshlayout:1.0.0",
+        swipeRefresh: "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0",
         coordinatorLayout: "androidx.coordinatorlayout:coordinatorlayout:1.1.0",
-        material: "com.google.android.material:material:1.1.0",
+        material: "com.google.android.material:material:1.2.1",
 
         // DI
-        koinAndroid: "org.koin:koin-android:2.1.6", // Koin for Android
-        koinLifecycle: "org.koin:koin-androidx-scope:2.1.6", // or Koin for Lifecycle scoping
-        koinViewModel: "org.koin:koin-androidx-viewmodel:2.1.6", // or Koin for Android Architecture ViewModel
-        koinFragment: "org.koin:koin-androidx-fragment:2.1.6", // or Koin for Android Fragment Factory (unstable version)
+        koinAndroid: "org.koin:koin-android:2.2.2", // Koin for Android
+        koinLifecycle: "org.koin:koin-androidx-scope:2.2.2", // or Koin for Lifecycle scoping
+        koinViewModel: "org.koin:koin-androidx-viewmodel:2.2.2", // or Koin for Android Architecture ViewModel
+        koinFragment: "org.koin:koin-androidx-fragment:2.2.2", // or Koin for Android Fragment Factory (unstable version)
     
         // Image download library
-        fresco: "com.facebook.fresco:fresco:2.2.0",
+        fresco: "com.facebook.fresco:fresco:2.3.0",
     
         // Crash reporting library
-        sentry: "io.sentry:sentry-android:2.1.0",
+        sentry: "io.sentry:sentry-android:3.2.0",
 
         // Analytics
-        amplitude: "com.amplitude:android-sdk:2.26.1",
+        amplitude: "com.amplitude:android-sdk:2.30.0",
 
         // Logging
         timber: 'com.jakewharton.timber:timber:4.7.1'
@@ -82,8 +82,8 @@ ext {
     ]
 
     TestConfig = [
-        jUnit: "junit:junit:4.12",
-        mockk: "io.mockk:mockk:1.9.3"
+        jUnit: "junit:junit:4.13.1",
+        mockk: "io.mockk:mockk:1.10.3"
     ]
 
 }

--- a/project-config/dependencies.gradle
+++ b/project-config/dependencies.gradle
@@ -1,5 +1,5 @@
 ext {
-    kotlinVersion = "1.4.20"
+    kotlinVersion = "1.4.21"
     gradleVersion = "4.1.1"
     jvmTargetVersion = "1.8"
     

--- a/project-config/feature-complete-build.gradle
+++ b/project-config/feature-complete-build.gradle
@@ -1,6 +1,5 @@
 apply plugin: "com.android.library"
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 
 apply from: "$rootDir/quality/test-coverage.gradle"

--- a/quality/ktlint.gradle
+++ b/quality/ktlint.gradle
@@ -2,7 +2,7 @@ configurations {
     ktlint
 }
 dependencies {
-    ktlint 'com.pinterest:ktlint:0.37.2'
+    ktlint 'com.pinterest:ktlint:0.40.0'
 }
 
 def outputDir = "${project.buildDir}/reports/ktlint/"

--- a/utility/utility-android/build.gradle
+++ b/utility/utility-android/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: "com.android.library"
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion AndroidConfig.compileSdk


### PR DESCRIPTION
## Context
Including a task to check dependency version updates.

https://github.com/ben-manes/gradle-versions-plugin
Usage: ./gradlew dependencyUpdates -Drevision=release

## Code
Generated report:
```
------------------------------------------------------------
: Project Dependency Updates (report to plain text file)
------------------------------------------------------------

The following dependencies are using the latest release version:
 - androidx.appcompat:appcompat:1.2.0
 - androidx.cardview:cardview:1.0.0
 - androidx.coordinatorlayout:coordinatorlayout:1.1.0
 - androidx.databinding:viewbinding:4.1.1
 - androidx.fragment:fragment-ktx:1.2.5
 - androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0
 - androidx.recyclerview:recyclerview:1.1.0
 - com.android.tools.build:gradle:4.1.1
 - com.github.ben-manes:gradle-versions-plugin:0.36.0
 - com.jakewharton.timber:timber:4.7.1
 - com.squareup.retrofit2:converter-moshi:2.9.0
 - com.squareup.retrofit2:retrofit:2.9.0
 - org.jetbrains.kotlin:kotlin-android-extensions:1.4.21
 - org.jetbrains.kotlin:kotlin-annotation-processing-gradle:1.4.21
 - org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.21
 - org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable:1.4.21

The following dependencies have later release versions:
 - androidx.constraintlayout:constraintlayout [1.1.3 -> 2.0.4]
     http://tools.android.com
 - androidx.core:core-ktx [1.3.1 -> 1.3.2]
     https://developer.android.com/jetpack/androidx
 - androidx.swiperefreshlayout:swiperefreshlayout [1.0.0 -> 1.1.0]
     https://developer.android.com/jetpack/androidx
 - com.amplitude:android-sdk [2.26.1 -> 2.30.0]
     https://github.com/amplitude/Amplitude-Android
 - com.facebook.fresco:fresco [2.2.0 -> 2.3.0]
     https://github.com/facebook/fresco
 - com.google.android.material:material [1.1.0 -> 1.2.1]
     https://github.com/material-components/material-components-android
 - com.pinterest:ktlint [0.37.2 -> 0.40.0]
     https://github.com/pinterest/ktlint
 - com.squareup.leakcanary:leakcanary-android [2.4 -> 2.5]
     http://github.com/square/leakcanary/
 - com.squareup.moshi:moshi [1.9.3 -> 1.11.0]
     https://github.com/square/moshi/
 - com.squareup.moshi:moshi-kotlin-codegen [1.9.3 -> 1.11.0]
     https://github.com/square/moshi/
 - io.mockk:mockk [1.9.3 -> 1.10.3]
     http://mockk.io
 - io.sentry:sentry-android [2.1.0 -> 3.2.0]
     https://github.com/getsentry/sentry-java
 - junit:junit [4.12 -> 4.13.1]
     http://junit.org
 - org.jetbrains.kotlinx:kotlinx-coroutines-core [1.3.9 -> 1.4.2]
     https://github.com/Kotlin/kotlinx.coroutines
 - org.koin:koin-android [2.1.6 -> 2.2.2]
 - org.koin:koin-androidx-fragment [2.1.6 -> 2.2.2]
 - org.koin:koin-androidx-scope [2.1.6 -> 2.2.2]
 - org.koin:koin-androidx-viewmodel [2.1.6 -> 2.2.2]

Failed to determine the latest version for the following dependencies (use --info for details):
 - org.jetbrains.kotlin:kotlin-android-extensions-runtime
     1.4.21
 - org.jetbrains.kotlin:kotlin-stdlib
     1.4.21
 - org.jetbrains.kotlin:kotlin-stdlib-jdk8
     1.4.21

Gradle release-candidate updates:
 - Gradle: [6.5 -> 6.7.1 -> 6.8-rc-4]

Generated report file build/dependencyUpdates/report.txt
```
