### PR TITLE
Using CDN provider instead of S3 directly

### DIFF
--- a/core-android/src/main/java/br/com/recipebook/coreandroid/configuration/Configuration.kt
+++ b/core-android/src/main/java/br/com/recipebook/coreandroid/configuration/Configuration.kt
@@ -1,5 +1,5 @@
 package br.com.recipebook.coreandroid.configuration
 
 object Configuration {
-    const val IMG_URL = "https://cm-recipe-book.s3-sa-east-1.amazonaws.com/images/"
+    const val IMG_URL = "https://d20y9ud0nwoqf1.cloudfront.net/images/"
 }

--- a/core-android/src/main/java/br/com/recipebook/coreandroid/di/CoreAndroidModule.kt
+++ b/core-android/src/main/java/br/com/recipebook/coreandroid/di/CoreAndroidModule.kt
@@ -20,7 +20,7 @@ val coreAndroidModule = module {
     }
     single {
         Retrofit.Builder()
-            .baseUrl("https://cm-recipe-book.s3-sa-east-1.amazonaws.com")
+            .baseUrl("https://d20y9ud0nwoqf1.cloudfront.net/")
             .client(get())
             .addConverterFactory(get())
             .build()


### PR DESCRIPTION
## Context
- To reduce costs, delivery content faster, protect from DDoS, I'm changing the base URL from a S3 to CloudFront provided. In the future I'll probably change again to a fixed domain name (and force app version update 👀 )

## Code
- Create CloudFront distribution
- Block S3 public access
- Change base URL