### PR TITLE
jcenter removal

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,6 +29,8 @@ android {
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
         }
         debug {
+            applicationIdSuffix ".debug"
+
             testCoverageEnabled = true
         }
     }
@@ -48,7 +50,8 @@ dependencies {
     implementation AndroidLibConfig.coreKtx
     implementation AndroidLibConfig.coroutinesCore
 
-    implementation AndroidLibConfig.koinAndroid
+    implementation AndroidLibConfig.koinCore
+    implementation AndroidLibConfig.koinAndroidExt
 
     implementation project(ProjectConfig.coreAndroid)
     implementation project(ProjectConfig.utilityAndroid)

--- a/build.gradle
+++ b/build.gradle
@@ -13,15 +13,8 @@ apply from: "$rootDir/quality/test-coverage-setup.gradle"
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     repositories {
-        //mavenCentral()
+        mavenCentral()
         google()
-//        jcenter {
-//            content {
-//                // https://youtrack.jetbrains.com/issue/IDEA-261387
-//                includeModule("org.jetbrains.trove4j", "trove4j")
-//            }
-//        }
-        jcenter()
     }
     ext {
         kotlinVersion = "1.4.32"
@@ -41,7 +34,6 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
         mavenCentral()
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -3,8 +3,8 @@ apply from: "project-config/dependencies.gradle"
 
 // Dependency version checker
 // Usage: ./gradlew dependencyUpdates -Drevision=release
-//apply plugin: "com.github.ben-manes.versions"
-//apply from: "project-config/dependencies-checker/dependencies-checker.gradle"
+apply plugin: "com.github.ben-manes.versions"
+apply from: "project-config/dependencies-checker/dependencies-checker.gradle"
 
 // Test coverage
 // Usage ./gradlew jacocoTestReport
@@ -15,6 +15,7 @@ buildscript {
     repositories {
         mavenCentral()
         google()
+        gradlePluginPortal() // ben-manes
     }
     ext {
         kotlinVersion = "1.4.32"
@@ -24,7 +25,7 @@ buildscript {
     dependencies {
         classpath "com.android.tools.build:gradle:$gradleVersion"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
-        //classpath "com.github.ben-manes:gradle-versions-plugin:0.36.0"
+        classpath "com.github.ben-manes:gradle-versions-plugin:0.38.0"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/build.gradle
+++ b/build.gradle
@@ -3,8 +3,8 @@ apply from: "project-config/dependencies.gradle"
 
 // Dependency version checker
 // Usage: ./gradlew dependencyUpdates -Drevision=release
-apply plugin: "com.github.ben-manes.versions"
-apply from: "project-config/dependencies-checker/dependencies-checker.gradle"
+//apply plugin: "com.github.ben-manes.versions"
+//apply from: "project-config/dependencies-checker/dependencies-checker.gradle"
 
 // Test coverage
 // Usage ./gradlew jacocoTestReport
@@ -13,18 +13,25 @@ apply from: "$rootDir/quality/test-coverage-setup.gradle"
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     repositories {
+        //mavenCentral()
         google()
+//        jcenter {
+//            content {
+//                // https://youtrack.jetbrains.com/issue/IDEA-261387
+//                includeModule("org.jetbrains.trove4j", "trove4j")
+//            }
+//        }
         jcenter()
     }
     ext {
-        kotlinVersion = "1.4.31"
-        gradleVersion = '4.1.2'
+        kotlinVersion = "1.4.32"
+        gradleVersion = '4.1.3'
     }
 
     dependencies {
         classpath "com.android.tools.build:gradle:$gradleVersion"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
-        classpath "com.github.ben-manes:gradle-versions-plugin:0.36.0"
+        //classpath "com.github.ben-manes:gradle-versions-plugin:0.36.0"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -35,6 +42,7 @@ allprojects {
     repositories {
         google()
         jcenter()
+        mavenCentral()
     }
 }
 

--- a/core-android/build.gradle
+++ b/core-android/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     implementation EnvironmentConfig.kotlinStdLib
     implementation AndroidLibConfig.coreKtx
 
-    implementation AndroidLibConfig.koinAndroid
+    implementation AndroidLibConfig.koinCore
 
     implementation AndroidLibConfig.retrofit
     implementation AndroidLibConfig.moshiConverter

--- a/infrastructure/analytics-amplitude/build.gradle
+++ b/infrastructure/analytics-amplitude/build.gradle
@@ -25,7 +25,9 @@ dependencies {
     implementation EnvironmentConfig.kotlinStdLib
     implementation AndroidLibConfig.coreKtx
 
-    implementation AndroidLibConfig.koinAndroid
+    implementation AndroidLibConfig.koinCore
+    implementation AndroidLibConfig.koinAndroidExt
+
     implementation AndroidLibConfig.amplitude
     implementation AndroidLibConfig.timber
 

--- a/infrastructure/analytics/build.gradle
+++ b/infrastructure/analytics/build.gradle
@@ -1,10 +1,5 @@
 apply plugin: 'kotlin'
 
-repositories {
-    google()
-    mavenCentral()
-}
-
 dependencies {
     implementation EnvironmentConfig.kotlinJdk
 }

--- a/infrastructure/analytics/build.gradle
+++ b/infrastructure/analytics/build.gradle
@@ -1,7 +1,8 @@
 apply plugin: 'kotlin'
 
 repositories {
-    jcenter()
+    google()
+    mavenCentral()
 }
 
 dependencies {

--- a/infrastructure/configuration/build.gradle
+++ b/infrastructure/configuration/build.gradle
@@ -26,7 +26,7 @@ dependencies {
     implementation EnvironmentConfig.kotlinJdk
     implementation AndroidLibConfig.coroutinesCore
 
-    implementation AndroidLibConfig.koinAndroid
+    implementation AndroidLibConfig.koinCore
 
     implementation project(ProjectConfig.utilityKotlin)
     implementation project(ProjectConfig.utilityAndroid)

--- a/infrastructure/device/build.gradle
+++ b/infrastructure/device/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     implementation EnvironmentConfig.kotlinJdk
     implementation AndroidLibConfig.coroutinesCore
 
-    implementation AndroidLibConfig.koinAndroid
+    implementation AndroidLibConfig.koinCore
 }
 
 java {

--- a/infrastructure/image/build.gradle
+++ b/infrastructure/image/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     implementation AndroidLibConfig.coreKtx
     implementation AndroidLibConfig.coroutinesCore
 
-    implementation AndroidLibConfig.koinAndroid
+    implementation AndroidLibConfig.koinCore
     implementation AndroidLibConfig.fresco
 
     implementation project(ProjectConfig.startup)

--- a/infrastructure/monitoring/build.gradle
+++ b/infrastructure/monitoring/build.gradle
@@ -25,7 +25,8 @@ dependencies {
     implementation EnvironmentConfig.kotlinStdLib
     implementation AndroidLibConfig.coreKtx
 
-    implementation AndroidLibConfig.koinAndroid
+    implementation AndroidLibConfig.koinCore
+
     implementation AndroidLibConfig.timber
     implementation AndroidLibConfig.sentry
     implementation AndroidLibConfig.okhttp

--- a/infrastructure/navigation/build.gradle
+++ b/infrastructure/navigation/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     implementation EnvironmentConfig.kotlinStdLib
     implementation AndroidLibConfig.coreKtx
 
-    implementation AndroidLibConfig.koinAndroid
+    implementation AndroidLibConfig.koinCore
 
     implementation project(ProjectConfig.coreAndroid)
     implementation project(ProjectConfig.utilityAndroid)

--- a/infrastructure/startup/build.gradle
+++ b/infrastructure/startup/build.gradle
@@ -1,7 +1,8 @@
 apply plugin: 'kotlin'
 
 repositories {
-    jcenter()
+    google()
+    mavenCentral()
 }
 
 dependencies {
@@ -10,7 +11,7 @@ dependencies {
     implementation AndroidLibConfig.coreKtx
     implementation AndroidLibConfig.coroutinesCore
 
-    implementation AndroidLibConfig.koinAndroid
+    implementation AndroidLibConfig.koinCore
 
     implementation project(ProjectConfig.utilityKotlin)
 

--- a/infrastructure/startup/build.gradle
+++ b/infrastructure/startup/build.gradle
@@ -1,10 +1,5 @@
 apply plugin: 'kotlin'
 
-repositories {
-    google()
-    mavenCentral()
-}
-
 dependencies {
     implementation EnvironmentConfig.kotlinJdk
     implementation EnvironmentConfig.kotlinStdLib

--- a/project-config/dependencies.gradle
+++ b/project-config/dependencies.gradle
@@ -22,7 +22,7 @@ ext {
     
     AndroidLibConfig = [
         coreKtx: "androidx.core:core-ktx:1.3.2",
-        coroutinesCore: "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.2",
+        coroutinesCore: "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.3",
 
         // Debug
         leakCanary: "com.squareup.leakcanary:leakcanary-android:2.6",
@@ -50,13 +50,11 @@ ext {
         playCoreExtensions: "com.google.android.play:core-ktx:1.8.1",
 
         // DI
-        koinAndroid: "org.koin:koin-android:2.2.2", // Koin for Android
-        koinLifecycle: "org.koin:koin-androidx-scope:2.2.2", // or Koin for Lifecycle scoping
-        koinViewModel: "org.koin:koin-androidx-viewmodel:2.2.2", // or Koin for Android Architecture ViewModel
-        koinFragment: "org.koin:koin-androidx-fragment:2.2.2", // or Koin for Android Fragment Factory (unstable version)
+        koinCore: "io.insert-koin:koin-core:3.0.1", // Koin Core
+        koinAndroidExt: "io.insert-koin:koin-android-ext:3.0.1", // Koin for Android
     
         // Image download library
-        fresco: "com.facebook.fresco:fresco:2.4.0",
+        fresco: "com.facebook.fresco:fresco:2.3.0",
     
         // Crash reporting library
         sentry: "io.sentry:sentry-android:4.2.0",

--- a/project-config/feature-complete-build.gradle
+++ b/project-config/feature-complete-build.gradle
@@ -36,9 +36,8 @@ dependencies {
     implementation AndroidLibConfig.coreKtx
     implementation AndroidLibConfig.coroutinesCore
 
-    implementation AndroidLibConfig.koinLifecycle
-    implementation AndroidLibConfig.koinViewModel
-    implementation AndroidLibConfig.koinFragment
+    implementation AndroidLibConfig.koinCore
+    implementation AndroidLibConfig.koinAndroidExt
 
     implementation AndroidLibConfig.retrofit
     implementation AndroidLibConfig.moshiConverter

--- a/utility/utility-kotlin/build.gradle
+++ b/utility/utility-kotlin/build.gradle
@@ -1,7 +1,8 @@
 apply plugin: 'kotlin'
 
 repositories {
-    jcenter()
+    google()
+    mavenCentral()
 }
 
 dependencies {

--- a/utility/utility-kotlin/build.gradle
+++ b/utility/utility-kotlin/build.gradle
@@ -1,10 +1,5 @@
 apply plugin: 'kotlin'
 
-repositories {
-    google()
-    mavenCentral()
-}
-
 dependencies {
     implementation EnvironmentConfig.kotlinJdk
     implementation AndroidLibConfig.coroutinesCore


### PR DESCRIPTION
## Context
Jcenter is shutting down
https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/

## Code
- Upgrade koin to 3.0.1 (changed the group id and moved to maven repository)
- Remove jcenter repository dependency
- Update dependency checker version
