### PR TITLE
Preparing detekt configuration for compose

### DIFF
--- a/.idea/detekt.xml
+++ b/.idea/detekt.xml
@@ -4,5 +4,6 @@
     <enableDetekt>true</enableDetekt>
     <enableFormatting>true</enableFormatting>
     <enableAllRules>true</enableAllRules>
+    <configPaths>$PROJECT_DIR$/quality/detekt/detekt-config.yml</configPaths>
   </component>
 </project>

--- a/core-android/src/main/java/br/com/recipebook/coreandroid/image/ImageResolver.kt
+++ b/core-android/src/main/java/br/com/recipebook/coreandroid/image/ImageResolver.kt
@@ -9,12 +9,12 @@ enum class ImageSize(val folder: String) {
     LARGE("original")
 }
 
-private const val SIZE_PLACEHOLDER = "{size}"
+private const val SizePlaceholder = "{size}"
 
 class ImageResolver {
     fun mountUrl(relativePath: String?, size: ImageSize): String? {
         return if (!relativePath.isNullOrBlank()) {
-            Configuration.IMG_URL + relativePath.replace(SIZE_PLACEHOLDER, size.folder)
+            Configuration.IMG_URL + relativePath.replace(SizePlaceholder, size.folder)
         } else {
             null
         }

--- a/features/in-app-update/src/main/java/br/com/recipebook/inappupdate/view/InAppUpdaterImpl.kt
+++ b/features/in-app-update/src/main/java/br/com/recipebook/inappupdate/view/InAppUpdaterImpl.kt
@@ -7,7 +7,7 @@ import br.com.recipebook.inappupdate.domain.InAppUpdater
 import br.com.recipebook.inappupdate.requestInAppUpdate
 import com.google.android.play.core.install.model.AppUpdateType
 
-private const val REQUEST_CODE = 1292
+private const val RequestCode = 1292
 
 internal class InAppUpdaterImpl(
     private val activityProvider: ActivityProvider,
@@ -15,7 +15,7 @@ internal class InAppUpdaterImpl(
     override suspend fun invoke(): InAppUpdateResult {
         return (activityProvider.activeActivity as? FragmentActivity)?.requestInAppUpdate(
             appUpdateType = AppUpdateType.IMMEDIATE,
-            requestCode = REQUEST_CODE
+            requestCode = RequestCode
         ) ?: InAppUpdateResult.UpdateFailed
     }
 }

--- a/features/settings-theme/src/main/java/br/com/recipebook/settings/theme/data/local/SettingsThemeLocalDataSource.kt
+++ b/features/settings-theme/src/main/java/br/com/recipebook/settings/theme/data/local/SettingsThemeLocalDataSource.kt
@@ -5,21 +5,21 @@ import androidx.core.content.edit
 import br.com.recipebook.settings.theme.data.SettingsThemeDataSource
 import br.com.recipebook.settings.theme.domain.model.UserThemePreferenceModel
 
-private const val KEY_CURRENT_THEME = "CURRENT_THEME"
+private const val KeyCurrentTheme = "CURRENT_THEME"
 
 class SettingsThemeLocalDataSource(
     private val sharedPreferences: SharedPreferences
 ) : SettingsThemeDataSource {
 
     override fun getCurrentTheme(): UserThemePreferenceModel {
-        return sharedPreferences.getString(KEY_CURRENT_THEME, null)?.let {
+        return sharedPreferences.getString(KeyCurrentTheme, null)?.let {
             UserThemePreferenceModel.valueOf(it)
         } ?: UserThemePreferenceModel.SYSTEM
     }
 
     override fun setCurrentTheme(theme: UserThemePreferenceModel) {
         sharedPreferences.edit {
-            putString(KEY_CURRENT_THEME, theme.name)
+            putString(KeyCurrentTheme, theme.name)
             apply()
         }
     }

--- a/features/settings-theme/src/main/java/br/com/recipebook/settings/theme/data/local/SettingsThemeSharedPreferences.kt
+++ b/features/settings-theme/src/main/java/br/com/recipebook/settings/theme/data/local/SettingsThemeSharedPreferences.kt
@@ -1,3 +1,3 @@
 package br.com.recipebook.settings.theme.data.local
 
-const val NAMED_SHARED_PREFERENCES_SETTINGS_THEME = "SharedPreferencesSettingsTheme"
+const val NamesSharedPreferencesSettingsTheme = "SharedPreferencesSettingsTheme"

--- a/features/settings-theme/src/main/java/br/com/recipebook/settings/theme/di/SettingsThemeModule.kt
+++ b/features/settings-theme/src/main/java/br/com/recipebook/settings/theme/di/SettingsThemeModule.kt
@@ -5,7 +5,7 @@ import android.content.SharedPreferences
 import br.com.recipebook.navigation.Navigator
 import br.com.recipebook.settings.theme.data.SettingsThemeDataSource
 import br.com.recipebook.settings.theme.data.SettingsThemeRepositoryImpl
-import br.com.recipebook.settings.theme.data.local.NAMED_SHARED_PREFERENCES_SETTINGS_THEME
+import br.com.recipebook.settings.theme.data.local.NamesSharedPreferencesSettingsTheme
 import br.com.recipebook.settings.theme.data.local.SettingsThemeLocalDataSource
 import br.com.recipebook.settings.theme.domain.repository.SettingsThemeRepository
 import br.com.recipebook.settings.theme.domain.usecase.ApplyUserThemePreference
@@ -59,12 +59,12 @@ val settingsDataModule = module {
     }
 
     factory<SettingsThemeDataSource> {
-        SettingsThemeLocalDataSource(get(named(NAMED_SHARED_PREFERENCES_SETTINGS_THEME)))
+        SettingsThemeLocalDataSource(get(named(NamesSharedPreferencesSettingsTheme)))
     }
 
-    factory<SharedPreferences>(named(NAMED_SHARED_PREFERENCES_SETTINGS_THEME)) {
+    factory<SharedPreferences>(named(NamesSharedPreferencesSettingsTheme)) {
         androidContext().getSharedPreferences(
-            NAMED_SHARED_PREFERENCES_SETTINGS_THEME,
+            NamesSharedPreferencesSettingsTheme,
             Context.MODE_PRIVATE
         )
     }

--- a/infrastructure/analytics-amplitude/src/main/java/br/com/recipebook/analytics/amplitude/AmplitudeAnalytics.kt
+++ b/infrastructure/analytics-amplitude/src/main/java/br/com/recipebook/analytics/amplitude/AmplitudeAnalytics.kt
@@ -12,7 +12,7 @@ import org.json.JSONObject
 import timber.log.Timber
 import kotlin.system.measureTimeMillis
 
-private const val ANALYTICS_LIBRARY_NAME = "Amplitude"
+private const val AnalyticsLibraryName = "Amplitude"
 
 class AmplitudeAnalytics(
     private val application: Application,
@@ -40,7 +40,7 @@ class AmplitudeAnalytics(
         isInitialized = true
         sendEvent(
             LibraryInitializationEvent(
-                libraryName = ANALYTICS_LIBRARY_NAME,
+                libraryName = AnalyticsLibraryName,
                 timeToInitialize = initTimeInMillis
             )
         )

--- a/quality/detekt/detekt-config.yml
+++ b/quality/detekt/detekt-config.yml
@@ -1,0 +1,810 @@
+build:
+  maxIssues: 0
+  excludeCorrectable: false
+  weights:
+  # complexity: 2
+  # LongParameterList: 1
+  # style: 1
+  # comments: 1
+
+config:
+  validation: true
+  warningsAsErrors: false
+  # when writing own rules with new properties, exclude the property path e.g.: 'my_rule_set,.*>.*>[my_property]'
+  excludes: ''
+
+processors:
+  active: true
+  exclude:
+    - 'DetektProgressListener'
+  # - 'KtFileCountProcessor'
+  # - 'PackageCountProcessor'
+  # - 'ClassCountProcessor'
+  # - 'FunctionCountProcessor'
+  # - 'PropertyCountProcessor'
+  # - 'ProjectComplexityProcessor'
+  # - 'ProjectCognitiveComplexityProcessor'
+  # - 'ProjectLLOCProcessor'
+  # - 'ProjectCLOCProcessor'
+  # - 'ProjectLOCProcessor'
+  # - 'ProjectSLOCProcessor'
+  # - 'LicenseHeaderLoaderExtension'
+
+console-reports:
+  active: true
+  exclude:
+    - 'ProjectStatisticsReport'
+    - 'ComplexityReport'
+    - 'NotificationReport'
+    #  - 'FindingsReport'
+    - 'FileBasedFindingsReport'
+    - 'LiteFindingsReport'
+
+output-reports:
+  active: true
+  exclude:
+  # - 'TxtOutputReport'
+  # - 'XmlOutputReport'
+  # - 'HtmlOutputReport'
+
+comments:
+  active: true
+  AbsentOrWrongFileLicense:
+    active: false
+    licenseTemplateFile: 'license.template'
+    licenseTemplateIsRegex: false
+  CommentOverPrivateFunction:
+    active: false
+  CommentOverPrivateProperty:
+    active: false
+  DeprecatedBlockTag:
+    active: false
+  EndOfSentenceFormat:
+    active: false
+    endOfSentenceFormat: '([.?!][ \t\n\r\f<])|([.?!:]$)'
+  OutdatedDocumentation:
+    active: false
+    matchTypeParameters: true
+    matchDeclarationsOrder: true
+  UndocumentedPublicClass:
+    active: false
+    excludes: ['**/test/**', '**/androidTest/**']
+    searchInNestedClass: true
+    searchInInnerClass: true
+    searchInInnerObject: true
+    searchInInnerInterface: true
+  UndocumentedPublicFunction:
+    active: false
+    excludes: ['**/test/**', '**/androidTest/**']
+  UndocumentedPublicProperty:
+    active: false
+    excludes: ['**/test/**', '**/androidTest/**']
+
+complexity:
+  active: true
+  ComplexCondition:
+    active: true
+    threshold: 4
+  ComplexInterface:
+    active: false
+    threshold: 10
+    includeStaticDeclarations: false
+    includePrivateDeclarations: false
+  ComplexMethod:
+    active: true
+    threshold: 15
+    ignoreSingleWhenExpression: false
+    ignoreSimpleWhenEntries: false
+    ignoreNestingFunctions: false
+    nestingFunctions:
+      - 'also'
+      - 'apply'
+      - 'forEach'
+      - 'isNotNull'
+      - 'ifNull'
+      - 'let'
+      - 'run'
+      - 'use'
+      - 'with'
+  LabeledExpression:
+    active: false
+    ignoredLabels: []
+  LargeClass:
+    active: true
+    threshold: 600
+  LongMethod:
+    active: true
+    threshold: 60
+  LongParameterList:
+    active: true
+    functionThreshold: 6
+    constructorThreshold: 7
+    ignoreDefaultParameters: true
+    ignoreDataClasses: true
+    ignoreAnnotatedParameter: []
+  MethodOverloading:
+    active: false
+    threshold: 6
+  NamedArguments:
+    active: false
+    threshold: 3
+  NestedBlockDepth:
+    active: true
+    threshold: 4
+  ReplaceSafeCallChainWithRun:
+    active: false
+  StringLiteralDuplication:
+    active: false
+    excludes: ['**/test/**', '**/androidTest/**']
+    threshold: 3
+    ignoreAnnotation: true
+    excludeStringsWithLessThan5Characters: true
+    ignoreStringsRegex: '$^'
+  TooManyFunctions:
+    active: true
+    excludes: ['**/test/**', '**/androidTest/**']
+    thresholdInFiles: 11
+    thresholdInClasses: 11
+    thresholdInInterfaces: 11
+    thresholdInObjects: 11
+    thresholdInEnums: 11
+    ignoreDeprecated: false
+    ignorePrivate: false
+    ignoreOverridden: false
+
+coroutines:
+  active: true
+  GlobalCoroutineUsage:
+    active: false
+  InjectDispatcher:
+    active: false
+    dispatcherNames:
+      - 'IO'
+      - 'Default'
+      - 'Unconfined'
+  RedundantSuspendModifier:
+    active: false
+  SleepInsteadOfDelay:
+    active: false
+  SuspendFunWithFlowReturnType:
+    active: false
+
+empty-blocks:
+  active: true
+  EmptyCatchBlock:
+    active: true
+    allowedExceptionNameRegex: '_|(ignore|expected).*'
+  EmptyClassBlock:
+    active: true
+  EmptyDefaultConstructor:
+    active: true
+  EmptyDoWhileBlock:
+    active: true
+  EmptyElseBlock:
+    active: true
+  EmptyFinallyBlock:
+    active: true
+  EmptyForBlock:
+    active: true
+  EmptyFunctionBlock:
+    active: true
+    ignoreOverridden: false
+  EmptyIfBlock:
+    active: true
+  EmptyInitBlock:
+    active: true
+  EmptyKtFile:
+    active: true
+  EmptySecondaryConstructor:
+    active: true
+  EmptyTryBlock:
+    active: true
+  EmptyWhenBlock:
+    active: true
+  EmptyWhileBlock:
+    active: true
+
+exceptions:
+  active: true
+  ExceptionRaisedInUnexpectedLocation:
+    active: true
+    methodNames:
+      - 'equals'
+      - 'finalize'
+      - 'hashCode'
+      - 'toString'
+  InstanceOfCheckForException:
+    active: false
+    excludes: ['**/test/**', '**/androidTest/**']
+  NotImplementedDeclaration:
+    active: false
+  ObjectExtendsThrowable:
+    active: false
+  PrintStackTrace:
+    active: true
+  RethrowCaughtException:
+    active: true
+  ReturnFromFinally:
+    active: true
+    ignoreLabeled: false
+  SwallowedException:
+    active: true
+    ignoredExceptionTypes:
+      - 'InterruptedException'
+      - 'MalformedURLException'
+      - 'NumberFormatException'
+      - 'ParseException'
+    allowedExceptionNameRegex: '_|(ignore|expected).*'
+  ThrowingExceptionFromFinally:
+    active: true
+  ThrowingExceptionInMain:
+    active: false
+  ThrowingExceptionsWithoutMessageOrCause:
+    active: true
+    excludes: ['**/test/**', '**/androidTest/**']
+    exceptions:
+      - 'ArrayIndexOutOfBoundsException'
+      - 'Exception'
+      - 'IllegalArgumentException'
+      - 'IllegalMonitorStateException'
+      - 'IllegalStateException'
+      - 'IndexOutOfBoundsException'
+      - 'NullPointerException'
+      - 'RuntimeException'
+      - 'Throwable'
+  ThrowingNewInstanceOfSameException:
+    active: true
+  TooGenericExceptionCaught:
+    active: true
+    excludes: ['**/test/**', '**/androidTest/**']
+    exceptionNames:
+      - 'ArrayIndexOutOfBoundsException'
+      - 'Error'
+      - 'Exception'
+      - 'IllegalMonitorStateException'
+      - 'IndexOutOfBoundsException'
+      - 'NullPointerException'
+      - 'RuntimeException'
+      - 'Throwable'
+    allowedExceptionNameRegex: '_|(ignore|expected).*'
+  TooGenericExceptionThrown:
+    active: true
+    exceptionNames:
+      - 'Error'
+      - 'Exception'
+      - 'RuntimeException'
+      - 'Throwable'
+
+formatting:
+  active: true
+  android: false
+  autoCorrect: true
+  AnnotationOnSeparateLine:
+    active: false
+    autoCorrect: true
+  AnnotationSpacing:
+    active: false
+    autoCorrect: true
+  ArgumentListWrapping:
+    active: false
+    autoCorrect: true
+    indentSize: 4
+    maxLineLength: 120
+  ChainWrapping:
+    active: true
+    autoCorrect: true
+  CommentSpacing:
+    active: true
+    autoCorrect: true
+  EnumEntryNameCase:
+    active: false
+    autoCorrect: true
+  Filename:
+    active: true
+  FinalNewline:
+    active: true
+    autoCorrect: true
+    insertFinalNewLine: true
+  ImportOrdering:
+    active: true
+    autoCorrect: true
+    layout: '*,java.**,javax.**,kotlin.**,^'
+  Indentation:
+    active: true
+    autoCorrect: true
+    indentSize: 4
+    continuationIndentSize: 4
+  MaximumLineLength:
+    active: true
+    maxLineLength: 120
+    ignoreBackTickedIdentifier: false
+  ModifierOrdering:
+    active: true
+    autoCorrect: true
+  MultiLineIfElse:
+    active: false
+    autoCorrect: true
+  NoBlankLineBeforeRbrace:
+    active: true
+    autoCorrect: true
+  NoConsecutiveBlankLines:
+    active: true
+    autoCorrect: true
+  NoEmptyClassBody:
+    active: true
+    autoCorrect: true
+  NoEmptyFirstLineInMethodBlock:
+    active: false
+    autoCorrect: true
+  NoLineBreakAfterElse:
+    active: true
+    autoCorrect: true
+  NoLineBreakBeforeAssignment:
+    active: true
+    autoCorrect: true
+  NoMultipleSpaces:
+    active: true
+    autoCorrect: true
+  NoSemicolons:
+    active: true
+    autoCorrect: true
+  NoTrailingSpaces:
+    active: true
+    autoCorrect: true
+  NoUnitReturn:
+    active: true
+    autoCorrect: true
+  NoUnusedImports:
+    active: true
+    autoCorrect: true
+  NoWildcardImports:
+    active: true
+  PackageName:
+    active: false
+    autoCorrect: true
+  ParameterListWrapping:
+    active: true
+    autoCorrect: true
+    indentSize: 4
+    maxLineLength: 120
+  SpacingAroundAngleBrackets:
+    active: false
+    autoCorrect: true
+  SpacingAroundColon:
+    active: true
+    autoCorrect: true
+  SpacingAroundComma:
+    active: true
+    autoCorrect: true
+  SpacingAroundCurly:
+    active: true
+    autoCorrect: true
+  SpacingAroundDot:
+    active: true
+    autoCorrect: true
+  SpacingAroundDoubleColon:
+    active: false
+    autoCorrect: true
+  SpacingAroundKeyword:
+    active: true
+    autoCorrect: true
+  SpacingAroundOperators:
+    active: true
+    autoCorrect: true
+  SpacingAroundParens:
+    active: true
+    autoCorrect: true
+  SpacingAroundRangeOperator:
+    active: true
+    autoCorrect: true
+  SpacingAroundUnaryOperator:
+    active: false
+    autoCorrect: true
+  SpacingBetweenDeclarationsWithAnnotations:
+    active: false
+    autoCorrect: true
+  SpacingBetweenDeclarationsWithComments:
+    active: false
+    autoCorrect: true
+  StringTemplate:
+    active: true
+    autoCorrect: true
+
+naming:
+  active: true
+  BooleanPropertyNaming:
+    active: false
+    excludes: ['**/test/**', '**/androidTest/**']
+    allowedPattern: '^(is|has|are)'
+  ClassNaming:
+    active: true
+    excludes: ['**/test/**', '**/androidTest/**']
+    classPattern: '[A-Z][a-zA-Z0-9]*'
+  ConstructorParameterNaming:
+    active: true
+    excludes: ['**/test/**', '**/androidTest/**']
+    parameterPattern: '[a-z][A-Za-z0-9]*'
+    privateParameterPattern: '[a-z][A-Za-z0-9]*'
+    excludeClassPattern: '$^'
+    ignoreOverridden: true
+  EnumNaming:
+    active: true
+    excludes: ['**/test/**', '**/androidTest/**']
+    enumEntryPattern: '[A-Z][_a-zA-Z0-9]*'
+  ForbiddenClassName:
+    active: false
+    excludes: ['**/test/**', '**/androidTest/**']
+    forbiddenName: []
+  FunctionMaxLength:
+    active: false
+    excludes: ['**/test/**', '**/androidTest/**']
+    maximumFunctionNameLength: 30
+  FunctionMinLength:
+    active: false
+    excludes: ['**/test/**', '**/androidTest/**']
+    minimumFunctionNameLength: 3
+  FunctionNaming:
+    active: true
+    excludes: ['**/test/**', '**/androidTest/**']
+    functionPattern: '([a-z][a-zA-Z0-9]*)|(`.*`)'
+    excludeClassPattern: '$^'
+    ignoreOverridden: true
+    ignoreAnnotated: ['Composable']
+  FunctionParameterNaming:
+    active: true
+    excludes: ['**/test/**', '**/androidTest/**']
+    parameterPattern: '[a-z][A-Za-z0-9]*'
+    excludeClassPattern: '$^'
+    ignoreOverridden: true
+  InvalidPackageDeclaration:
+    active: false
+    rootPackage: ''
+  LambdaParameterNaming:
+    active: false
+    excludes: ['**/test/**', '**/androidTest/**']
+    parameterPattern: '[a-z][A-Za-z0-9]*|_'
+  MatchingDeclarationName:
+    active: true
+    mustBeFirst: true
+  MemberNameEqualsClassName:
+    active: true
+    ignoreOverridden: true
+  NoNameShadowing:
+    active: false
+  NonBooleanPropertyPrefixedWithIs:
+    active: false
+    excludes: ['**/test/**', '**/androidTest/**']
+  ObjectPropertyNaming:
+    active: true
+    excludes: ['**/test/**', '**/androidTest/**']
+    constantPattern: '[A-Za-z][_A-Za-z0-9]*'
+    propertyPattern: '[A-Za-z][_A-Za-z0-9]*'
+    privatePropertyPattern: '(_)?[A-Za-z][_A-Za-z0-9]*'
+  PackageNaming:
+    active: true
+    excludes: ['**/test/**', '**/androidTest/**']
+    packagePattern: '[a-z]+(\.[a-z][A-Za-z0-9]*)*'
+  TopLevelPropertyNaming:
+    active: true
+    excludes: ['**/test/**', '**/androidTest/**']
+    constantPattern: '[A-Z][A-Za-z0-9]*'
+    propertyPattern: '[A-Za-z][_A-Za-z0-9]*'
+    privatePropertyPattern: '_?[A-Za-z][_A-Za-z0-9]*'
+  VariableMaxLength:
+    active: false
+    excludes: ['**/test/**', '**/androidTest/**']
+    maximumVariableNameLength: 64
+  VariableMinLength:
+    active: false
+    excludes: ['**/test/**', '**/androidTest/**']
+    minimumVariableNameLength: 1
+  VariableNaming:
+    active: true
+    excludes: ['**/test/**', '**/androidTest/**']
+    variablePattern: '[a-z][A-Za-z0-9]*'
+    privateVariablePattern: '(_)?[a-z][A-Za-z0-9]*'
+    excludeClassPattern: '$^'
+    ignoreOverridden: true
+
+performance:
+  active: true
+  ArrayPrimitive:
+    active: true
+  ForEachOnRange:
+    active: true
+    excludes: ['**/test/**', '**/androidTest/**']
+  SpreadOperator:
+    active: true
+    excludes: ['**/test/**', '**/androidTest/**']
+  UnnecessaryTemporaryInstantiation:
+    active: true
+
+potential-bugs:
+  active: true
+  AvoidReferentialEquality:
+    active: false
+    forbiddenTypePatterns:
+      - 'kotlin.String'
+  CastToNullableType:
+    active: false
+  Deprecation:
+    active: false
+  DontDowncastCollectionTypes:
+    active: false
+  DoubleMutabilityForCollection:
+    active: false
+  DuplicateCaseInWhenExpression:
+    active: true
+  EqualsAlwaysReturnsTrueOrFalse:
+    active: true
+  EqualsWithHashCodeExist:
+    active: true
+  ExitOutsideMain:
+    active: false
+  ExplicitGarbageCollectionCall:
+    active: true
+  HasPlatformType:
+    active: false
+  IgnoredReturnValue:
+    active: false
+    restrictToAnnotatedMethods: true
+    returnValueAnnotations:
+      - '*.CheckResult'
+      - '*.CheckReturnValue'
+    ignoreReturnValueAnnotations:
+      - '*.CanIgnoreReturnValue'
+  ImplicitDefaultLocale:
+    active: true
+  ImplicitUnitReturnType:
+    active: false
+    allowExplicitReturnType: true
+  InvalidRange:
+    active: true
+  IteratorHasNextCallsNextMethod:
+    active: true
+  IteratorNotThrowingNoSuchElementException:
+    active: true
+  LateinitUsage:
+    active: false
+    excludes: ['**/test/**', '**/androidTest/**']
+    ignoreOnClassesPattern: ''
+  MapGetWithNotNullAssertionOperator:
+    active: false
+  MissingPackageDeclaration:
+    active: false
+    excludes: ['**/*.kts']
+  MissingWhenCase:
+    active: true
+    allowElseExpression: true
+  NullableToStringCall:
+    active: false
+  RedundantElseInWhen:
+    active: true
+  UnconditionalJumpStatementInLoop:
+    active: false
+  UnnecessaryNotNullOperator:
+    active: true
+  UnnecessarySafeCall:
+    active: true
+  UnreachableCatchBlock:
+    active: false
+  UnreachableCode:
+    active: true
+  UnsafeCallOnNullableType:
+    active: true
+    excludes: ['**/test/**', '**/androidTest/**']
+  UnsafeCast:
+    active: true
+  UnusedUnaryOperator:
+    active: false
+  UselessPostfixExpression:
+    active: false
+  WrongEqualsTypeParameter:
+    active: true
+
+style:
+  active: true
+  ClassOrdering:
+    active: false
+  CollapsibleIfStatements:
+    active: false
+  DataClassContainsFunctions:
+    active: false
+    conversionFunctionPrefix: 'to'
+  DataClassShouldBeImmutable:
+    active: false
+  DestructuringDeclarationWithTooManyEntries:
+    active: false
+    maxDestructuringEntries: 3
+  EqualsNullCall:
+    active: true
+  EqualsOnSignatureLine:
+    active: false
+  ExplicitCollectionElementAccessMethod:
+    active: false
+  ExplicitItLambdaParameter:
+    active: false
+  ExpressionBodySyntax:
+    active: false
+    includeLineWrapping: false
+  ForbiddenComment:
+    active: true
+    values:
+      - 'FIXME:'
+      - 'STOPSHIP:'
+      - 'TODO:'
+    allowedPatterns: ''
+    customMessage: ''
+  ForbiddenImport:
+    active: false
+    imports: []
+    forbiddenPatterns: ''
+  ForbiddenMethodCall:
+    active: false
+    methods:
+      - 'kotlin.io.print'
+      - 'kotlin.io.println'
+  ForbiddenPublicDataClass:
+    active: true
+    excludes: ['**']
+    ignorePackages:
+      - '*.internal'
+      - '*.internal.*'
+  ForbiddenVoid:
+    active: false
+    ignoreOverridden: false
+    ignoreUsageInGenerics: false
+  FunctionOnlyReturningConstant:
+    active: true
+    ignoreOverridableFunction: true
+    ignoreActualFunction: true
+    excludedFunctions: ''
+  LibraryCodeMustSpecifyReturnType:
+    active: true
+    excludes: ['**']
+  LibraryEntitiesShouldNotBePublic:
+    active: true
+    excludes: ['**']
+  LoopWithTooManyJumpStatements:
+    active: true
+    maxJumpCount: 1
+  MagicNumber:
+    active: true
+    excludes: ['**/test/**', '**/androidTest/**']
+    ignoreNumbers:
+      - '-1'
+      - '0'
+      - '1'
+      - '2'
+    ignoreHashCodeFunction: true
+    ignorePropertyDeclaration: true
+    ignoreLocalVariableDeclaration: false
+    ignoreConstantDeclaration: true
+    ignoreCompanionObjectPropertyDeclaration: true
+    ignoreAnnotation: false
+    ignoreNamedArgument: true
+    ignoreEnums: false
+    ignoreRanges: false
+    ignoreExtensionFunctions: true
+  MandatoryBracesIfStatements:
+    active: false
+  MandatoryBracesLoops:
+    active: false
+  MaxLineLength:
+    active: true
+    maxLineLength: 120
+    excludePackageStatements: true
+    excludeImportStatements: true
+    excludeCommentStatements: false
+  MayBeConst:
+    active: true
+  ModifierOrder:
+    active: true
+  MultilineLambdaItParameter:
+    active: false
+  NestedClassesVisibility:
+    active: true
+  NewLineAtEndOfFile:
+    active: true
+  NoTabs:
+    active: false
+  ObjectLiteralToLambda:
+    active: false
+  OptionalAbstractKeyword:
+    active: true
+  OptionalUnit:
+    active: false
+  OptionalWhenBraces:
+    active: false
+  PreferToOverPairSyntax:
+    active: false
+  ProtectedMemberInFinalClass:
+    active: true
+  RedundantExplicitType:
+    active: false
+  RedundantHigherOrderMapUsage:
+    active: false
+  RedundantVisibilityModifierRule:
+    active: false
+  ReturnCount:
+    active: true
+    max: 2
+    excludedFunctions: 'equals'
+    excludeLabeled: false
+    excludeReturnFromLambda: true
+    excludeGuardClauses: false
+  SafeCast:
+    active: true
+  SerialVersionUIDInSerializableClass:
+    active: true
+  SpacingBetweenPackageAndImports:
+    active: false
+  ThrowsCount:
+    active: true
+    max: 2
+    excludeGuardClauses: false
+  TrailingWhitespace:
+    active: false
+  UnderscoresInNumericLiterals:
+    active: false
+    acceptableLength: 4
+  UnnecessaryAbstractClass:
+    active: true
+  UnnecessaryAnnotationUseSiteTarget:
+    active: false
+  UnnecessaryApply:
+    active: true
+  UnnecessaryFilter:
+    active: false
+  UnnecessaryInheritance:
+    active: true
+  UnnecessaryLet:
+    active: false
+  UnnecessaryParentheses:
+    active: false
+  UntilInsteadOfRangeTo:
+    active: false
+  UnusedImports:
+    active: false
+  UnusedPrivateClass:
+    active: true
+  UnusedPrivateMember:
+    active: true
+    allowedNames: '(_|ignored|expected|serialVersionUID)'
+    ignoreAnnotated: ['Preview']
+  UseAnyOrNoneInsteadOfFind:
+    active: false
+  UseArrayLiteralsInAnnotations:
+    active: false
+  UseCheckNotNull:
+    active: false
+  UseCheckOrError:
+    active: false
+  UseDataClass:
+    active: false
+    allowVars: false
+  UseEmptyCounterpart:
+    active: false
+  UseIfEmptyOrIfBlank:
+    active: false
+  UseIfInsteadOfWhen:
+    active: false
+  UseIsNullOrEmpty:
+    active: false
+  UseOrEmpty:
+    active: false
+  UseRequire:
+    active: false
+  UseRequireNotNull:
+    active: false
+  UselessCallOnNotNull:
+    active: true
+  UtilityClassWithPublicConstructor:
+    active: true
+  VarCouldBeVal:
+    active: true
+  WildcardImport:
+    active: true
+    excludes: ['**/test/**', '**/androidTest/**']
+    excludeImports:
+      - 'java.util.*'

--- a/quality/detekt/detekt-install.sh
+++ b/quality/detekt/detekt-install.sh
@@ -5,17 +5,17 @@
 mkdir -p .tools
 
 echo "Downloading detekt cli"
-curl -sSL https://github.com/detekt/detekt/releases/download/v1.19.0-RC2/detekt-cli-1.19.0-RC2.zip -o .tools/detekt-cli.zip
+curl -sSL https://github.com/detekt/detekt/releases/download/v1.19.0/detekt-cli-1.19.0.zip -o .tools/detekt-cli.zip
 
 echo "Extracting detekt cli..."
 unzip -q .tools/detekt-cli.zip -d .tools/
 
 rm -rf .tools/detekt-cli
-mv .tools/detekt-cli-1.19.0-RC2 .tools/detekt-cli
+mv .tools/detekt-cli-1.19.0 .tools/detekt-cli
 rm .tools/detekt-cli.zip
 
 echo "Downloading detekt ktlint formatting"
 rm .tools/detekt-formatting.jar
-curl -sSL https://repo1.maven.org/maven2/io/gitlab/arturbosch/detekt/detekt-formatting/1.19.0-RC2/detekt-formatting-1.19.0-RC2.jar -o .tools/detekt-formatting.jar
+curl -sSL https://repo1.maven.org/maven2/io/gitlab/arturbosch/detekt/detekt-formatting/1.19.0/detekt-formatting-1.19.0.jar -o .tools/detekt-formatting.jar
 
 echo "Installation finished"

--- a/quality/detekt/detekt-run.sh
+++ b/quality/detekt/detekt-run.sh
@@ -10,11 +10,12 @@ done
 
 # Install detekt cli if necessary
 DETEKT_VERSION=$(.tools/detekt-cli/bin/detekt-cli --version)
-if [[ $DETEKT_VERSION != "1.19.0-RC2" ]]; then
+if [[ $DETEKT_VERSION != "1.19.0" ]]; then
   ./quality/detekt/detekt-install.sh
 fi
 
 CMD=".tools/detekt-cli/bin/detekt-cli --all-rules \
+--config quality/detekt/detekt-config.yml \
 --plugins .tools/detekt-formatting.jar \
 --excludes \"**/build/**,$EXCLUDE_PATHS\" "
 

--- a/utility/utility-android/src/main/java/br/com/recipebook/utilityandroid/view/ViewExtensions.kt
+++ b/utility/utility-android/src/main/java/br/com/recipebook/utilityandroid/view/ViewExtensions.kt
@@ -8,7 +8,7 @@ import androidx.fragment.app.Fragment
 import kotlin.properties.ReadOnlyProperty
 import kotlin.reflect.KProperty
 
-private const val SCREEN_ARGS = "SCREEN_ARGS"
+private const val ScreenArgs = "SCREEN_ARGS"
 
 fun <V : Any> safeArgs() = object : ReadOnlyProperty<Fragment, V> {
     var value: V? = null
@@ -20,7 +20,7 @@ fun <V : Any> safeArgs() = object : ReadOnlyProperty<Fragment, V> {
         if (value == null) {
             val args = thisRef.arguments
                 ?: throw IllegalArgumentException("There are no fragment arguments!")
-            val argUntyped = args.get(SCREEN_ARGS)
+            val argUntyped = args.get(ScreenArgs)
             argUntyped
                 ?: throw IllegalArgumentException("Screen arguments not found at key SCREEN_ARGS!")
             @Suppress("UNCHECKED_CAST")
@@ -32,7 +32,7 @@ fun <V : Any> safeArgs() = object : ReadOnlyProperty<Fragment, V> {
 
 fun <T : Fragment> T.putSafeArgs(parcelable: Parcelable): T =
     apply {
-        arguments = Bundle().apply { putParcelable(SCREEN_ARGS, parcelable) }
+        arguments = Bundle().apply { putParcelable(ScreenArgs, parcelable) }
     }
 
 fun <V : Any> activitySafeArgs() = object : ReadOnlyProperty<Activity, V> {
@@ -45,7 +45,7 @@ fun <V : Any> activitySafeArgs() = object : ReadOnlyProperty<Activity, V> {
         if (value == null) {
             val args = thisRef.intent.extras
                 ?: throw IllegalArgumentException("There are no activity arguments!")
-            val argUntyped = args.get(SCREEN_ARGS)
+            val argUntyped = args.get(ScreenArgs)
             argUntyped
                 ?: throw IllegalArgumentException("Screen arguments not found at key SCREEN_ARGS!")
             @Suppress("UNCHECKED_CAST")
@@ -56,5 +56,5 @@ fun <V : Any> activitySafeArgs() = object : ReadOnlyProperty<Activity, V> {
 }
 
 fun Intent.putSafeArgs(value: Parcelable) {
-    putExtra(SCREEN_ARGS, value)
+    putExtra(ScreenArgs, value)
 }


### PR DESCRIPTION
## Context
- Jetpack Compose has a few different code patterns that needs to be configured for detekt. 

## Code
- Include a configuration file with [adjustments for compose](https://detekt.github.io/detekt/compose.html)
- Set detekt plugin with configuration file
- Update detekt verstion to 1.19.0
- Fix issues
