### PR TITLE
Migrate deprecated onBackButton call

### DIFF
--- a/features/recipe-detail/src/main/java/br/com/recipebook/recipedetail/view/RecipeDetailActivity.kt
+++ b/features/recipe-detail/src/main/java/br/com/recipebook/recipedetail/view/RecipeDetailActivity.kt
@@ -35,7 +35,7 @@ class RecipeDetailActivity : AppCompatActivity() {
                         RecipeDetailView(
                             state = it,
                             statusBarHeight = getStatusBarHeight().dp,
-                            onBackClick = ::onBackPressed,
+                            onBackClick = { onBackPressedDispatcher.onBackPressed() },
                         )
                     }
                 }

--- a/features/settings-theme/src/main/java/br/com/recipebook/settings/theme/view/SettingsThemeActivity.kt
+++ b/features/settings-theme/src/main/java/br/com/recipebook/settings/theme/view/SettingsThemeActivity.kt
@@ -26,7 +26,7 @@ class SettingsThemeActivity : AppCompatActivity() {
                     RecipeBookTheme {
                         SettingsThemeView(
                             state = it,
-                            onBackClick = ::onBackPressed,
+                            onBackClick = { onBackPressedDispatcher.onBackPressed() },
                             onItemClick = ::onItemClick,
                         )
                     }

--- a/features/settings/src/main/java/br/com/recipebook/settings/view/SettingsActivity.kt
+++ b/features/settings/src/main/java/br/com/recipebook/settings/view/SettingsActivity.kt
@@ -32,7 +32,7 @@ class SettingsActivity : AppCompatActivity() {
                     RecipeBookTheme {
                         SettingsView(
                             state = it,
-                            onBackClick = ::onBackPressed,
+                            onBackClick = { onBackPressedDispatcher.onBackPressed() },
                             onItemClick = ::onItemClick,
                         )
                     }


### PR DESCRIPTION
## Context
- `Activity.onBackPressed` is now deprecated

## Code
- Migrate `Activity.onBackPressed` to `onBackPressedDispatcher.onBackPressed()`
